### PR TITLE
Update the webv instances created by terraform to use latest image

### DIFF
--- a/src/modules/aci/main.tf
+++ b/src/modules/aci/main.tf
@@ -39,7 +39,7 @@ resource "azurerm_container_group" helium-aci {
 
   container {
     name     = "${var.NAME}-webv-${each.key}"
-    image    = "retaildevcrew/webvalidate:debug"
+    image    = "retaildevcrew/webvalidate:latest"
     commands = ["dotnet", "../webvalidate.dll", "--server", "${var.NAME}", "--files", "${var.CONTAINER_FILE_NAME}", "--base-url", "https://raw.githubusercontent.com/retaildevcrews/${var.REPO}/master/TestFiles/", "--run-loop", "--sleep", "${each.value}", "--summary-minutes", "5", "--json-log", "--tag", "${each.key}"]
     cpu      = "0.5"
     memory   = "1.5"

--- a/src/modules/aci/main.tf
+++ b/src/modules/aci/main.tf
@@ -40,7 +40,7 @@ resource "azurerm_container_group" helium-aci {
   container {
     name     = "${var.NAME}-webv-${each.key}"
     image    = "retaildevcrew/webvalidate:latest"
-    commands = ["dotnet", "../webvalidate.dll", "--server", "${var.NAME}", "--files", "${var.CONTAINER_FILE_NAME}", "--base-url", "https://raw.githubusercontent.com/retaildevcrews/${var.REPO}/master/TestFiles/", "--run-loop", "--sleep", "${each.value}", "--summary-minutes", "5", "--json-log", "--tag", "${each.key}"]
+    commands = ["dotnet", "../webvalidate.dll", "--server", "${var.NAME}", "--files", "${var.CONTAINER_FILE_NAME}", "--base-url", "https://raw.githubusercontent.com/retaildevcrews/${var.REPO}/main/TestFiles/", "--run-loop", "--sleep", "${each.value}", "--summary-minutes", "5", "--json-log", "--tag", "${each.key}"]
     cpu      = "0.5"
     memory   = "1.5"
 


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR

Update webv container instances to use "latest" image instead of "debug" image. Update reference to test files in helium from "master" to "main". The csharp repo has been updated from "master" to "main". This will work for all 3 languages after the java and typescript renames are done.

### Validation
- [x] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

### Issues Closed or Referenced

- References https://github.com/retaildevcrews/helium-terraform/issues/27
