### PR TITLE
Fix sed errors in create-tf-vars.sh on macOS

### DIFF
--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -32,36 +32,36 @@ fi
 
 cat ../example.tfvars | \
 # replace name
-  sed "s/<<He_Name>>/$He_Name/" | \
+  sed "s|<<He_Name>>|$He_Name|" | \
 
 # replace location
-  sed "s/<<He_Location>>/$He_Location/" | \
+  sed "s|<<He_Location>>|$He_Location|" | \
 
 # replace repo
-  sed "s/<<He_Repo>>/$He_Repo/" | \
+  sed "s|<<He_Repo>>|$He_Repo|" | \
 
 # replace email
-  sed "s/<<He_Email>>/$He_Email/" | \
+  sed "s|<<He_Email>>|$He_Email|" | \
 
 # replace TF_TENANT_ID
-  sed "s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/" | \
+  sed "s|<<HE_TENANT_ID>>|$(az account show -o tsv --query tenantId)|" | \
 
 # replace TF_SUB_ID
-  sed "s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/" | \
+  sed "s|<<HE_SUB_ID>>|$(az account show -o tsv --query id)|" | \
 
 # create a service principal
 # replace TF_CLIENT_SECRET
-  sed "s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/" | \
+  sed "s|<<HE_CLIENT_SECRET>>|$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)|" | \
 
 # replace TF_CLIENT_ID
-  sed "s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/" | \
+  sed "s|<<HE_CLIENT_ID>>|$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)|" | \
 
 # create a service principal
 # replace ACR_SP_SECRET
-  sed "s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/" | \
+  sed "s|<<HE_ACR_SP_SECRET>>|$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)|" | \
 
 # replace ACR_SP_ID
-  sed "s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/" > terraform.tfvars
+  sed "s|<<HE_ACR_SP_ID>>|$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)|" > terraform.tfvars
 
 # validate the substitutions
 cat terraform.tfvars

--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -32,36 +32,36 @@ fi
 
 cat ../example.tfvars | \
 # replace name
-  sed "s/<<He_Name>>|$He_Name/g" | \
+  sed "s/<<He_Name>>/$He_Name/" | \
 
 # replace location
-  sed "s/<<He_Location>>/$He_Location/g" | \
+  sed "s/<<He_Location>>/$He_Location/" | \
 
 # replace repo
-  sed "s/<<He_Repo>>/$He_Repo/g" | \
+  sed "s/<<He_Repo>>/$He_Repo/" | \
 
 # replace email
-  sed "s/<<He_Email>>/$He_Email/g" | \
+  sed "s/<<He_Email>>/$He_Email/" | \
 
 # replace TF_TENANT_ID
-  sed "s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/g" | \
+  sed "s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/" | \
 
 # replace TF_SUB_ID
-  sed "s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/g" | \
+  sed "s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/" | \
 
 # create a service principal
 # replace TF_CLIENT_SECRET
-  sed "s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/g" | \
+  sed "s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/" | \
 
 # replace TF_CLIENT_ID
-  sed "s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/g" | \
+  sed "s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/" | \
 
 # create a service principal
 # replace ACR_SP_SECRET
-  sed "s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/g" | \
+  sed "s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/" | \
 
 # replace ACR_SP_ID
-  sed "s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/g" > terraform.tfvars
+  sed "s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/" > terraform.tfvars
 
 # validate the substitutions
 cat terraform.tfvars

--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -30,37 +30,38 @@ fi
 
 # create terraform.tfvars and replace template values
 
+cat ../example.tfvars | \
 # replace name
-cat ../example.tfvars | sed "s/<<He_Name>>/$He_Name/g" > terraform.tfvars
+  sed "s/<<He_Name>>|$He_Name/g" | \
 
 # replace location
-sed -i "s/<<He_Location>>/$He_Location/g" terraform.tfvars
+  sed "s/<<He_Location>>/$He_Location/g" | \
 
 # replace repo
-sed -i "s/<<He_Repo>>/$He_Repo/g" terraform.tfvars
+  sed "s/<<He_Repo>>/$He_Repo/g" | \
 
 # replace email
-sed -i "s/<<He_Email>>/$He_Email/g" terraform.tfvars
+  sed "s/<<He_Email>>/$He_Email/g" | \
 
 # replace TF_TENANT_ID
-sed -i "s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/g" terraform.tfvars
+  sed "s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/g" | \
 
 # replace TF_SUB_ID
-sed -i "s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/g" terraform.tfvars
+  sed "s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/g" | \
 
 # create a service principal
 # replace TF_CLIENT_SECRET
-sed -i "s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/g" terraform.tfvars
+  sed "s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/g" | \
 
 # replace TF_CLIENT_ID
-sed -i "s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/g" terraform.tfvars
+  sed "s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/g" | \
 
 # create a service principal
 # replace ACR_SP_SECRET
-sed -i "s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/g" terraform.tfvars
+  sed "s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/g" | \
 
 # replace ACR_SP_ID
-sed -i "s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/g" terraform.tfvars
+  sed "s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/g" > terraform.tfvars
 
 # validate the substitutions
 cat terraform.tfvars


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

### Purpose of PR
Fixes bug detailed in issue below.

Main cause of bug was macOS variant of sed requires -i flag to be followed by extension string (in this case ".tfvars") but doing so would mess up sed command from Linux/WSL.

Fixed by using sed on stream instead of in place file.

By doing so, sped up script by a factor of 3.

### Validation
- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

### Issues Closed or Referenced

- Closes: https://github.com/retaildevcrews/helium-terraform/issues/26
