### PR TITLE
Replace sed with ex in create-tf-vars.sh to for macOS

### DIFF
--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -30,38 +30,38 @@ fi
 
 # create terraform.tfvars and replace template values
 
-cat ../example.tfvars | \
+cat ../example.tfvars > terraform.tfvars
 # replace name
-  sed "s|<<He_Name>>|$He_Name|" | \
+sed "s|<<He_Name>>|$He_Name|" terraform.tfvars terraform.tfvars > terraform.tfvars
 
 # replace location
-  sed "s|<<He_Location>>|$He_Location|" | \
+sed "s|<<He_Location>>|$He_Location|" terraform.tfvars > terraform.tfvars
 
 # replace repo
-  sed "s|<<He_Repo>>|$He_Repo|" | \
+sed "s|<<He_Repo>>|$He_Repo|" terraform.tfvars > terraform.tfvars
 
 # replace email
-  sed "s|<<He_Email>>|$He_Email|" | \
+sed "s|<<He_Email>>|$He_Email|" terraform.tfvars > terraform.tfvars
 
 # replace TF_TENANT_ID
-  sed "s|<<HE_TENANT_ID>>|$(az account show -o tsv --query tenantId)|" | \
+sed "s|<<HE_TENANT_ID>>|$(az account show -o tsv --query tenantId)|" terraform.tfvars > terraform.tfvars
 
 # replace TF_SUB_ID
-  sed "s|<<HE_SUB_ID>>|$(az account show -o tsv --query id)|" | \
+sed "s|<<HE_SUB_ID>>|$(az account show -o tsv --query id)|" terraform.tfvars > terraform.tfvars
 
 # create a service principal
 # replace TF_CLIENT_SECRET
-  sed "s|<<HE_CLIENT_SECRET>>|$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)|" | \
+sed "s|<<HE_CLIENT_SECRET>>|$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)|" terraform.tfvars > terraform.tfvars
 
 # replace TF_CLIENT_ID
-  sed "s|<<HE_CLIENT_ID>>|$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)|" | \
+sed "s|<<HE_CLIENT_ID>>|$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)|" terraform.tfvars > terraform.tfvars
 
 # create a service principal
 # replace ACR_SP_SECRET
-  sed "s|<<HE_ACR_SP_SECRET>>|$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)|" | \
+sed "s|<<HE_ACR_SP_SECRET>>|$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)|" terraform.tfvars > terraform.tfvars
 
 # replace ACR_SP_ID
-  sed "s|<<HE_ACR_SP_ID>>|$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)|" > terraform.tfvars
+sed "s|<<HE_ACR_SP_ID>>|$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)|" terraform.tfvars > terraform.tfvars
 
 # validate the substitutions
 cat terraform.tfvars

--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -32,7 +32,7 @@ fi
 
 cat ../example.tfvars > terraform.tfvars
 # replace name
-sed "s|<<He_Name>>|$He_Name|" terraform.tfvars terraform.tfvars > terraform.tfvars
+sed "s|<<He_Name>>|$He_Name|" terraform.tfvars > terraform.tfvars
 
 # replace location
 sed "s|<<He_Location>>|$He_Location|" terraform.tfvars > terraform.tfvars

--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -30,38 +30,39 @@ fi
 
 # create terraform.tfvars and replace template values
 
-cat ../example.tfvars > terraform.tfvars
+cp ../example.tfvars terraform.tfvars
+
 # replace name
-sed "s|<<He_Name>>|$He_Name|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<He_Name>>/$He_Name/g|x" terraform.tfvars
 
 # replace location
-sed "s|<<He_Location>>|$He_Location|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<He_Location>>/$He_Location/g|x" terraform.tfvars
 
 # replace repo
-sed "s|<<He_Repo>>|$He_Repo|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<He_Repo>>/$He_Repo/g|x" terraform.tfvars
 
 # replace email
-sed "s|<<He_Email>>|$He_Email|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<He_Email>>/$He_Email/g|x" terraform.tfvars
 
 # replace TF_TENANT_ID
-sed "s|<<HE_TENANT_ID>>|$(az account show -o tsv --query tenantId)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_TENANT_ID>>/$(az account show -o tsv --query tenantId)/g|x" terraform.tfvars
 
 # replace TF_SUB_ID
-sed "s|<<HE_SUB_ID>>|$(az account show -o tsv --query id)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_SUB_ID>>/$(az account show -o tsv --query id)/g|x" terraform.tfvars
 
 # create a service principal
 # replace TF_CLIENT_SECRET
-sed "s|<<HE_CLIENT_SECRET>>|$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_CLIENT_SECRET>>/$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)/g|x" terraform.tfvars
 
 # replace TF_CLIENT_ID
-sed "s|<<HE_CLIENT_ID>>|$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_CLIENT_ID>>/$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)/g|x" terraform.tfvars
 
 # create a service principal
 # replace ACR_SP_SECRET
-sed "s|<<HE_ACR_SP_SECRET>>|$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_ACR_SP_SECRET>>/$(az ad sp create-for-rbac --skip-assignment -n http://${He_Name}-acr-sp --query password -o tsv)/g|x" terraform.tfvars
 
 # replace ACR_SP_ID
-sed "s|<<HE_ACR_SP_ID>>|$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)|" terraform.tfvars > terraform.tfvars
+ex -s -c "%s/<<HE_ACR_SP_ID>>/$(az ad sp show --id http://${He_Name}-acr-sp --query appId -o tsv)/g|x" terraform.tfvars
 
 # validate the substitutions
 cat terraform.tfvars


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
follow up on PR to [fix sed errors on macOS](https://github.com/retaildevcrews/helium-terraform/pull/30).

in place file editing using ex instead of sed because of macOS compatibility issues

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- References https://github.com/retaildevcrews/helium-terraform/issues/26
