### PR TITLE
Updated storage account name in create-tf-vars.sh

### DIFF
--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -79,9 +79,9 @@ if echo ${TFSTATE_RG_NAME} > /dev/null 2>&1 && echo ${He_Location} > /dev/null 2
     echo "Created Resource Group: ${TFSTATE_RG_NAME} in ${TF_LOCATION}"
 fi
 
-# create storage account for state file
+# create storage account for state file; storage account name (TFSA_NAME) must be < 24 characters
 export TFSUB_ID=$(az account show -o tsv --query id)
-export TFSA_NAME=tfstate$RANDOM
+export TFSA_NAME=tfstate$He_Name
 echo "Creating State File Storage Account and Container"
 if echo ${TFSUB_ID} > /dev/null 2>&1; then
     if ! az storage account create --resource-group $TFSTATE_RG_NAME --name $TFSA_NAME --sku Standard_LRS --encryption-services blob -o table; then

--- a/src/root/create-tf-vars.sh
+++ b/src/root/create-tf-vars.sh
@@ -79,7 +79,7 @@ if echo ${TFSTATE_RG_NAME} > /dev/null 2>&1 && echo ${He_Location} > /dev/null 2
     echo "Created Resource Group: ${TFSTATE_RG_NAME} in ${TF_LOCATION}"
 fi
 
-# create storage account for state file; storage account name (TFSA_NAME) must be < 24 characters
+# create storage account for state file
 export TFSUB_ID=$(az account show -o tsv --query id)
 export TFSA_NAME=tfstate$He_Name
 echo "Creating State File Storage Account and Container"


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Updated storage account naming convention in create-tf-vars.sh to use $He_Name instead of $RANDOM. Storage account names need to be unique across Azure. Since He_Name is unique, it should work as a unique storage account name.

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- References #helium-terraform/issues/18
