### PR TITLE
Start of AKS deployment for terraform. Documentation and initial resource group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # --------------------------------------------------------------------------------
-# File created using 'AnGitIgnored' extensions for Visual Studio Code: 
-# https://marketplace.visualstudio.com/items?itemName=AnAppWiLos.angitignored 
+# File created using 'AnGitIgnored' extensions for Visual Studio Code:
+# https://marketplace.visualstudio.com/items?itemName=AnAppWiLos.angitignored
 #-------------------------------------------------------------------------------
 
 
@@ -15,7 +15,7 @@
 
 *tfstate*
 *tfplan*
-src/root/main_tf_state.tf
+main_tf_state.tf
 
 .vscode/
 

--- a/src/aks/README.md
+++ b/src/aks/README.md
@@ -25,7 +25,6 @@ He_Name=[your unique name]
 az cosmosdb check-name-exists -n ${He_Name}
 
 ### if nslookup doesn't fail to resolve, change He_Name
-nslookup ${He_Name}.azurewebsites.net
 nslookup ${He_Name}.vault.azure.net
 nslookup ${He_Name}.azurecr.io
 
@@ -111,5 +110,16 @@ EOF
 
 # initialize terraform
 terraform init
+
+# validate terraform config
+terraform validate
+
+```
+
+Run terraform. Review the planned changes, and type 'yes' if the plan is what is expected.
+
+```bash
+
+terraform apply
 
 ```

--- a/src/aks/README.md
+++ b/src/aks/README.md
@@ -84,9 +84,9 @@ cat <<EOF > ./main_tf_state.tf
 terraform {
   required_version = ">= 0.13"
   backend "azurerm" {
-    resource_group_name  = "${TFSTATE_RG_NAME}"
-    storage_account_name = "${TFSA_NAME}"
-    container_name       = "${TFSA_CONTAINER}"
+    resource_group_name  = "$TFSTATE_RG_NAME"
+    storage_account_name = "$TFSA_NAME"
+    container_name       = "$TFSA_CONTAINER"
     key                  = "prod.terraform.tfstate"
   }
 }
@@ -94,12 +94,12 @@ EOF
 
 # save terraform variables
 cat <<EOF > ./terraform.tfvars
-LOCATION         = "${He_Location}"
-NAME             = "${He_Name}"
-TF_CLIENT_ID     = "${HE_CLIENT_ID}"
-TF_CLIENT_SECRET = "${HE_CLIENT_SECRET}"
-TF_SUB_ID        = "${HE_SUB_ID}"
-TF_TENANT_ID     = "${HE_TENANT_ID}"
+LOCATION         = "$He_Location"
+NAME             = "$He_Name"
+TF_CLIENT_ID     = "$HE_CLIENT_ID"
+TF_CLIENT_SECRET = "$HE_CLIENT_SECRET"
+TF_SUB_ID        = "$HE_SUB_ID"
+TF_TENANT_ID     = "$HE_TENANT_ID"
 EOF
 
 ```

--- a/src/aks/README.md
+++ b/src/aks/README.md
@@ -62,8 +62,7 @@ az group create --name ${TFSTATE_RG_NAME} --location ${He_Location} -o table
 
 # set a name for the terraform storage account
 # must be a unique name across all of azure.
-# $RANDOM is used for a better chance of having a unique name.
-TFSA_NAME=tfstate$RANDOM
+TFSA_NAME=tfstate$He_Name
 
 # create storage account for terraform state file
 az storage account create --resource-group $TFSTATE_RG_NAME --name $TFSA_NAME --sku Standard_LRS --encryption-services blob -o table

--- a/src/aks/README.md
+++ b/src/aks/README.md
@@ -34,20 +34,21 @@ nslookup ${He_Name}.azurecr.io
 ### Set additional values
 
 ```bash
+
 # Set location for resources
 He_Location=centralus
-
-# tenant id of the account
-HE_TENANT_ID=$(az account show -o tsv --query tenantId)
-
-# current subscription id
-HE_SUB_ID=$(az account show -o tsv --query id)
 
 ```
 
 ### Setup terraform backend
 
 ```bash
+
+# tenant id of the account
+HE_TENANT_ID=$(az account show -o tsv --query tenantId)
+
+# current subscription id
+HE_SUB_ID=$(az account show -o tsv --query id)
 
 # create service principal for terraform
 HE_CLIENT_SECRET=$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)
@@ -79,6 +80,7 @@ az storage container create --name $TFSA_CONTAINER --account-name $TFSA_NAME --a
 ### Create terraform config files
 
 ```bash
+
 # save terraform backend definition
 cat <<EOF > ./main_tf_state.tf
 terraform {
@@ -101,6 +103,7 @@ TF_CLIENT_SECRET = "${HE_CLIENT_SECRET}"
 TF_SUB_ID        = "${HE_SUB_ID}"
 TF_TENANT_ID     = "${HE_TENANT_ID}"
 EOF
+
 ```
 
 ### Run terraform

--- a/src/aks/README.md
+++ b/src/aks/README.md
@@ -1,0 +1,113 @@
+# Setup AKS with pod identity
+
+## Setup
+
+```bash
+
+# Clone this repo if not using Codespaces
+git clone https://github.com/retaildevcrews/helium-terraform
+
+cd helium-terraform/src/aks
+
+```
+
+### Choose a unique DNS name
+
+```bash
+
+# this will be the prefix for all resources
+# only use a-z and 0-9 - do not include punctuation or uppercase characters
+# must be at least 5 characters long
+# must start with a-z (only lowercase)
+He_Name=[your unique name]
+
+### if true, change He_Name
+az cosmosdb check-name-exists -n ${He_Name}
+
+### if nslookup doesn't fail to resolve, change He_Name
+nslookup ${He_Name}.azurewebsites.net
+nslookup ${He_Name}.vault.azure.net
+nslookup ${He_Name}.azurecr.io
+
+```
+
+### Set additional values
+
+```bash
+# Set location for resources
+He_Location=centralus
+
+# tenant id of the account
+HE_TENANT_ID=$(az account show -o tsv --query tenantId)
+
+# current subscription id
+HE_SUB_ID=$(az account show -o tsv --query id)
+
+```
+
+### Setup terraform backend
+
+```bash
+
+# create service principal for terraform
+HE_CLIENT_SECRET=$(az ad sp create-for-rbac -n http://${He_Name}-tf-sp --query password -o tsv)
+
+# client id of terraform service principal
+HE_CLIENT_ID=$(az ad sp show --id http://${He_Name}-tf-sp --query appId -o tsv)
+
+# create terraform resource group
+TFSTATE_RG_NAME=$He_Name-rg-tf
+az group create --name ${TFSTATE_RG_NAME} --location ${He_Location} -o table
+
+# set a name for the terraform storage account
+# must be a unique name across all of azure.
+# $RANDOM is used for a better chance of having a unique name.
+TFSA_NAME=tfstate$RANDOM
+
+# create storage account for terraform state file
+az storage account create --resource-group $TFSTATE_RG_NAME --name $TFSA_NAME --sku Standard_LRS --encryption-services blob -o table
+
+# storage account access key
+ARM_ACCESS_KEY=$(az storage account keys list --resource-group $TFSTATE_RG_NAME --account-name $TFSA_NAME --query [0].value -o tsv)
+
+# create storage account container
+TFSA_CONTAINER="container${TFSA_NAME}"
+az storage container create --name $TFSA_CONTAINER --account-name $TFSA_NAME --account-key $ARM_ACCESS_KEY -o table
+
+```
+
+### Create terraform config files
+
+```bash
+# save terraform backend definition
+cat <<EOF > ./main_tf_state.tf
+terraform {
+  required_version = ">= 0.13"
+  backend "azurerm" {
+    resource_group_name  = "${TFSTATE_RG_NAME}"
+    storage_account_name = "${TFSA_NAME}"
+    container_name       = "${TFSA_CONTAINER}"
+    key                  = "prod.terraform.tfstate"
+  }
+}
+EOF
+
+# save terraform variables
+cat <<EOF > ./terraform.tfvars
+LOCATION         = "${He_Location}"
+NAME             = "${He_Name}"
+TF_CLIENT_ID     = "${HE_CLIENT_ID}"
+TF_CLIENT_SECRET = "${HE_CLIENT_SECRET}"
+TF_SUB_ID        = "${HE_SUB_ID}"
+TF_TENANT_ID     = "${HE_TENANT_ID}"
+EOF
+```
+
+### Run terraform
+
+```bash
+
+# initialize terraform
+terraform init
+
+```

--- a/src/aks/main.tf
+++ b/src/aks/main.tf
@@ -1,0 +1,18 @@
+provider "azurerm" {
+  version = "~> 2.19"
+  features {}
+
+  subscription_id = var.TF_SUB_ID
+  client_id       = var.TF_CLIENT_ID
+  client_secret   = var.TF_CLIENT_SECRET
+  tenant_id       = var.TF_TENANT_ID
+}
+
+provider "azuread" {
+  version = "~> 0.11"
+
+  subscription_id = var.TF_SUB_ID
+  client_id       = var.TF_CLIENT_ID
+  client_secret   = var.TF_CLIENT_SECRET
+  tenant_id       = var.TF_TENANT_ID
+}

--- a/src/aks/main.tf
+++ b/src/aks/main.tf
@@ -16,3 +16,8 @@ provider "azuread" {
   client_secret   = var.TF_CLIENT_SECRET
   tenant_id       = var.TF_TENANT_ID
 }
+
+resource "azurerm_resource_group" "helium-app" {
+  name     = "${var.NAME}-rg-app"
+  location = var.LOCATION
+}

--- a/src/aks/variables.tf
+++ b/src/aks/variables.tf
@@ -1,0 +1,29 @@
+variable "NAME" {
+  type        = string
+  description = "The prefix which should be used for all resources in this example. Used by all modules"
+}
+
+variable "TF_CLIENT_ID" {
+  type        = string
+  description = "The Client ID(AppID) of the Service Principal that TF will use to Authenticate and build resources as. This account should have at least Contributor Role on the subscription. This is only used by the parent main.tf"
+}
+
+variable "TF_CLIENT_SECRET" {
+  type        = string
+  description = "The Client Secret of the Service Principal that TF will use to Authenticate and build resources as. This account should have at least Contributor Role on the subscription. This is only used by the parent main.tf"
+}
+
+variable "TF_TENANT_ID" {
+  type        = string
+  description = "This is the tenant ID of the Azure subscription. This is only used by the parent main.tf"
+}
+
+variable "TF_SUB_ID" {
+  type        = string
+  description = "The Subscription ID for the Terrafrom Service Principal to build resources in.This is only used by the parent main.tf"
+}
+
+variable "LOCATION" {
+  type        = string
+  description = "The Azure Region in which all resources in this example should be created. Used by all modules"
+}


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

The beginning of the work to add an AKS deployment to the helium-terraform setup. The decision was made to start this work in a new root(src/aks) folder for terraform. The main reason is to isolate these work-in-progress changes from the rest of the already working code for the App Service deployment. This will allow for quick iteration, and remove the risk of breaking the existing working code for App Service.

I've reused variable names to make it easier to see potential integration points back into the App Service deployment. Since there will be a lot of overlap, ACI for webv, Cosmos DB, Key Vault, etc, it would be beneficial to reuse modules. But, more work is needed to prep the modules for reuse, and that is out of scope for our immediate needs. 

Includes:
- new terraform root directory for AKS
- new documentation for setting up remote state backend
- resource group for AKS

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #39 
- References #31 
