### PR TITLE
added command to assign execute permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ export He_Repo=helium-csharp
 # create tfvars file
 ./create-tf-vars.sh
 
+# assign execute permission
+chmod +x ./create-tf-vars.sh
+
 # initialize
 terraform init
 


### PR DESCRIPTION
# Type of PR

- [* ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

A step should be part of documentation to assign execute permissions before executing the create-tf-vars.sh script.

It gave me permission denied error. 

## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References #issue_number (this references the issue but does not close with PR)
